### PR TITLE
Add instructions for installing from FreeBSD packages/ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ Installing from Packages
 ``FreeBSD``
 
 From packages:
+
     $ pkg install hitch
 
 From ports:
+
     $ cd /usr/ports/security/hitch && make install clean
 
 Usage

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ To install `hitch`:
     $ make
     $ sudo make install
 
+Installing from Packages
+------------------------
+
+``FreeBSD``
+
+From packages:
+    $ pkg install hitch
+
+From ports:
+    $ cd /usr/ports/security/hitch && make install clean
+
 Usage
 -----
 


### PR DESCRIPTION
I just added hitch to the FreeBSD ports tree:
https://freshports.org/security/hitch

Update the README to include instructions on how FreeBSD users can install hitch from the ports tree.