### PR TITLE
Add /usr/local/sbin to PATH so the binary can be found.

### DIFF
--- a/init.hitch
+++ b/init.hitch
@@ -151,7 +151,7 @@ ULIMIT_N=""
 # EOF
 }
 
-PATH="${PATH}:."
+PATH="${PATH}:/usr/local/sbin:."
 INSTANCE_NAME=""
 HITCH=`which hitch-openssl 2>/dev/null`
 


### PR DESCRIPTION
The default make install target is /usr/local/sbin which is not in PATH on EL6 / EL7.