### PR TITLE
proposed patch for setgroup, as described in POS36-C

### DIFF
--- a/src/hitch.c
+++ b/src/hitch.c
@@ -49,6 +49,7 @@
 #include <limits.h>
 #include <syslog.h>
 #include <stdarg.h>
+#include <grp.h>
 
 #include <ctype.h>
 #include <sched.h>
@@ -2025,9 +2026,9 @@ void change_root() {
 }
 
 void drop_privileges() {
-    if (CONFIG->GID >= 0 && setgid(CONFIG->GID) < 0)
+    if (CONFIG->GID >= 0 && setgroups(0, NULL) && setgid(CONFIG->GID) < 0)
         fail("setgid failed");
-    if (CONFIG->UID >= 0 && setuid(CONFIG->UID) < 0)
+    if (CONFIG->UID >= 0 && setgroups(0, NULL) && setuid(CONFIG->UID) < 0)
         fail("setuid failed");
 }
 


### PR DESCRIPTION
According to "The CERT C Secure Coding Standard", when dropping privileges by switching uid/gid, one should always use setgroup to make sure that membership of other groups are dropped as well. This is discussed for example at http://ow.ly/OpPFH

This is for issue #31

Ingvar
