### PR TITLE
Add support for transitioning from PROXY V1 protocol on the incoming side to X-Forwarded-For on the outgoing side

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,9 @@ AM_MAINTAINER_MODE([disable])
 # Checks for libraries.
 AC_CHECK_LIB([ev], [ev_default_loop], [], AC_MSG_ERROR([Cannot find libev headers.]))
 AC_CHECK_LIB([ssl], [SSL_CTX_free], [], AC_MSG_ERROR([Cannot find libssl headers.]))
+AC_CHECK_MEMBERS([struct stat.st_mtim, struct stat.st_mtimespec], [nsec_avail="true"], [])
+AM_CONDITIONAL(NSEC_AVAIL, [test "x$nsec_avail" == xtrue])
+AM_COND_IF(NSEC_AVAIL, [], AC_MSG_WARN([Nanosecond resolution not available from struct stat]))
 
 AC_ARG_ENABLE(sessioncache,
     AC_HELP_STRING([--enable-sessioncache],

--- a/hitch.conf.ex
+++ b/hitch.conf.ex
@@ -23,6 +23,10 @@ backend = "[127.0.0.1]:6081"
 # type: string
 pem-file = ""
 
+# Password for private key in PEM file OPTIONAL.
+# pem-keypass = "mypassword"
+pem-keypass = "example"
+
 # SSL protocol.
 #
 # tls = on
@@ -130,5 +134,18 @@ proxy-proxy = off
 #
 # type: boolean
 sni-nomatch-abort = off
+
+# Read client address using HAProxy PROXY protocol line, see
+# http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt
+# for details. This address will be reported to the backend
+# if one of write-ip or write-proxy is specified.
+#
+# type: boolean
+read-proxy = off
+
+# Report client address using X-Forwarded-For header.
+#
+# type: boolean
+write-xff = off
 
 # EOF

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -466,8 +466,13 @@ config_param_pem_file(char *filename, struct cfg_cert_file **cfptr)
 	ALLOC_OBJ(cert, CFG_CERT_FILE_MAGIC);
 	AN(cert);
 	config_assign_str(&cert->filename, filename);
-	cert->mtim = st.st_mtim.tv_sec
-	    + st.st_mtim.tv_nsec * 1e-9;
+	cert->mtim = st.st_mtime;
+#if defined(HAVE_STRUCT_STAT_ST_MTIM)
+	cert->mtim += st.st_mtim.tv_nsec * 1e-9;
+#elif defined(HAVE_STRUCT_STAT_ST_MTIMESPEC)
+	cert->mtim += st.st_mtimespec.tv_nsec * 1e-9;
+#endif
+
 
 	*cfptr = cert;
 	cert->ref++;

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "miniobj.h"
 #include "configuration.h"
+#include "libgen.h"
 
 #define AZ(foo)		do { assert((foo) == 0); } while (0)
 #define AN(foo)		do { assert((foo) != 0); } while (0)
@@ -128,6 +129,7 @@ config_new(void)
 	r->WRITE_PROXY_LINE_V2= 0;
 	r->PROXY_PROXY_LINE   = 0;
 	r->WRITE_XFF_LINE     = 0;
+	r->READ_PROXY_LINE	 = 0;
 	r->CHROOT             = NULL;
 	r->UID                = -1;
 	r->GID                = -1;
@@ -1001,9 +1003,9 @@ config_print_usage_fd(char *prog, hitch_config *cfg, FILE *out)
 	fprintf(out, "                              --write-proxy-v1 explicitly\n");
 	fprintf(out, "      --write-xff            Write X-Forwarded-For header before actual data\n" );
 	fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->WRITE_XFF_LINE));
-	fprintf(out, "      --read-proxy           Read HAProxy's PROXY (IPv4 or IPv6) protocol line\n" );
+	fprintf(out, "      --read-proxy           Read HAProxy's PROXY V1 (IPv4 or IPv6) protocol line\n" );
 	fprintf(out, "                             before actual data.  This address will be sent to\n");
-	fprintf(out, "                             the backend if one of --write-ip or --write-proxy\n");
+	fprintf(out, "                             the backend if one of --write-ip, --write-xff, or --write-proxy\n");
 	fprintf(out, "                             is specified.\n");
 	fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->READ_PROXY_LINE));
 	fprintf(out, "      --proxy-proxy          Proxy HaProxy's PROXY (IPv4 or IPv6) protocol line\n" );

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -51,7 +51,10 @@
 #define CFG_WRITE_PROXY "write-proxy"
 #define CFG_WRITE_PROXY_V1 "write-proxy-v1"
 #define CFG_WRITE_PROXY_V2 "write-proxy-v2"
+#define CFG_WRITE_XFF "write-xff"
+#define CFG_READ_PROXY "read-proxy"
 #define CFG_PEM_FILE "pem-file"
+#define CFG_PEM_KEYPASS "pem-keypass"
 #define CFG_PROXY_PROXY "proxy-proxy"
 #define CFG_BACKEND_CONNECT_TIMEOUT "backend-connect-timeout"
 #define CFG_SSL_HANDSHAKE_TIMEOUT "ssl-handshake-timeout"
@@ -124,6 +127,7 @@ config_new(void)
 	r->WRITE_PROXY_LINE_V1= 0;
 	r->WRITE_PROXY_LINE_V2= 0;
 	r->PROXY_PROXY_LINE   = 0;
+	r->WRITE_XFF_LINE     = 0;
 	r->CHROOT             = NULL;
 	r->UID                = -1;
 	r->GID                = -1;
@@ -733,6 +737,10 @@ config_param_validate(char *k, char *v, hitch_config *cfg,
 		r = config_param_val_bool(v, &cfg->WRITE_PROXY_LINE_V2);
 	} else if (strcmp(k, CFG_PROXY_PROXY) == 0) {
 		r = config_param_val_bool(v, &cfg->PROXY_PROXY_LINE);
+   } else if (strcmp(k, CFG_WRITE_XFF) == 0) {
+		r = config_param_val_bool(v, &cfg->WRITE_XFF_LINE);
+	} else if (strcmp(k, CFG_READ_PROXY) == 0) {
+		    r = config_param_val_bool(v, &cfg->READ_PROXY_LINE);
 	} else if (strcmp(k, CFG_PEM_FILE) == 0) {
 		struct cfg_cert_file *cert;
 		r = config_param_pem_file(v, &cert);
@@ -745,6 +753,14 @@ config_param_validate(char *k, char *v, hitch_config *cfg,
 				    tmp);
 			}
 			cfg->CERT_DEFAULT = cert;
+		}
+	} else if (strcmp(k, CFG_PEM_KEYPASS) == 0) {
+		// this should only be null if we haven't hit the value yet.
+		// if we hit it a second time it's an error
+		if (cfg->PEM_KEYPASS == NULL) {
+			config_assign_str(&cfg->PEM_KEYPASS, v);
+		} else {
+			config_error_set("Duplicate PEM private key passwords");
 		}
 	} else if (strcmp(k, CFG_BACKEND_CONNECT_TIMEOUT) == 0) {
 		r = config_param_val_int(v, &cfg->BACKEND_CONNECT_TIMEOUT, 1);
@@ -978,6 +994,13 @@ config_print_usage_fd(char *prog, hitch_config *cfg, FILE *out)
 	fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->WRITE_PROXY_LINE_V2));
 	fprintf(out, "      --write-proxy          Equivalent to --write-proxy-v2. For PROXY version 1 use\n");
 	fprintf(out, "                              --write-proxy-v1 explicitly\n");
+	fprintf(out, "      --write-xff            Write X-Forwarded-For header before actual data\n" );
+	fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->WRITE_XFF_LINE));
+	fprintf(out, "      --read-proxy           Read HAProxy's PROXY (IPv4 or IPv6) protocol line\n" );
+	fprintf(out, "                             before actual data.  This address will be sent to\n");
+	fprintf(out, "                             the backend if one of --write-ip or --write-proxy\n");
+	fprintf(out, "                             is specified.\n");
+	fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->READ_PROXY_LINE));
 	fprintf(out, "      --proxy-proxy          Proxy HaProxy's PROXY (IPv4 or IPv6) protocol line\n" );
 	fprintf(out, "                             before actual data (PROXY v1 only)\n");
 	fprintf(out, "                             (Default: %s)\n", config_disp_bool(cfg->PROXY_PROXY_LINE));
@@ -1040,6 +1063,8 @@ config_parse_cli(int argc, char **argv, hitch_config *cfg, int *retval)
 		{ CFG_WRITE_PROXY_V1, 0, &cfg->WRITE_PROXY_LINE_V1, 1 },
 		{ CFG_WRITE_PROXY_V2, 0, &cfg->WRITE_PROXY_LINE_V2, 1 },
 		{ CFG_WRITE_PROXY, 0, &cfg->WRITE_PROXY_LINE_V2, 1 },
+		{ CFG_WRITE_XFF, 0, &cfg->WRITE_XFF_LINE, 1 },
+		{ CFG_READ_PROXY, 0, &cfg->READ_PROXY_LINE, 1 },
 		{ CFG_PROXY_PROXY, 0, &cfg->PROXY_PROXY_LINE, 1 },
 		{ CFG_SNI_NOMATCH_ABORT, 0, &cfg->SNI_NOMATCH_ABORT, 1 },
 		{ "test", 0, NULL, 't' },

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -63,6 +63,8 @@ struct __hitch_config {
     int WRITE_PROXY_LINE_V1;
     int WRITE_PROXY_LINE_V2;
     int PROXY_PROXY_LINE;
+	 int WRITE_XFF_LINE;
+	 int READ_PROXY_LINE;
     char *CHROOT;
     int UID;
     int GID;
@@ -84,6 +86,7 @@ struct __hitch_config {
     char *SHCUPD_MCASTIF;
     char *SHCUPD_MCASTTTL;
 #endif
+	 char *PEM_KEYPASS;
     int QUIET;
     int SYSLOG;
     int SYSLOG_FACILITY;


### PR DESCRIPTION
Might not be of interest to a general audience however in our hosting environment we wanted to add some features.  We did this a couple of years ago with stud, ending up having changes pulled into insom/stud.  This is a hand merge of the changes into hitch, merging with git itself was do-able but ended up being a very large set of changes(obviously).  This would make reviewing the changes a painful exercise.
- Added arguments and configuration options for config file.
  - pem-keypass -- supply password for key file
  - write-xff -- take information from PROXY V1 protocol and write X-Forwarded-For on clear side
  - read-proxy -- only read in PROXY V1 protocol, do not pass it on, for use with write-xff option to translate PROXYV1 to X-Forwarded-For during ssl unwrap.
- Change to autoconf to detect type of time structs available in the stat struct on platform and use correct struct for nanosecond resolution of mtime.
