### PR TITLE
Build: allow rst2man with out-of-tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 SUBDIRS = src
 
 hitch.8: hitch.man.rst
-	rst2man --halt=2 hitch.man.rst $@
+	rst2man --halt=2 $(srcdir)/hitch.man.rst $@
 
 doc_DATA = hitch.conf.ex CHANGES.rst README.md
 


### PR DESCRIPTION
This is required in order to compile hitch in an out-of-tree build such as:

    mkdir build/
    cd build
    ../configure
    make