### PR TITLE
Include header for basename

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -17,6 +17,7 @@
 #include <grp.h>
 #include <sys/stat.h>
 #include <syslog.h>
+#include <libgen.h>
 
 #include "config.h"
 #include "miniobj.h"


### PR DESCRIPTION
Fixes a warning on FreeBSD.  Checking:

    man 3 basename

shows that we need `libgen.h` for basename().