### PR TITLE
Use pkg-config where possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,8 +27,11 @@ fi
 AM_MAINTAINER_MODE([disable])
 
 # Checks for libraries.
-AC_CHECK_LIB([ev], [ev_default_loop], [], AC_MSG_ERROR([Cannot find libev headers.]))
-AC_CHECK_LIB([ssl], [SSL_CTX_free], [], AC_MSG_ERROR([Cannot find libssl headers.]))
+PKG_CHECK_EXISTS([libev], [
+  PKG_CHECK_MODULES([EV], libev)], [
+  AC_SEARCH_LIBS([ev_default_loop], [ev], [], AC_MSG_ERROR([Cannot find libev.]))
+])
+PKG_CHECK_MODULES([SSL], libssl)
 AC_CHECK_MEMBERS([struct stat.st_mtim, struct stat.st_mtimespec], [nsec_avail="true"], [])
 AM_CONDITIONAL(NSEC_AVAIL, [test "x$nsec_avail" == xtrue])
 AM_COND_IF(NSEC_AVAIL, [], AC_MSG_WARN([Nanosecond resolution not available from struct stat]))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ sbin_PROGRAMS = hitch
 
 EXTRA_DIST = tests
 
-AM_CPPFLAGS = -I/usr/include/libev/
+AM_CPPFLAGS = $(EV_CFLAGS)
 AM_CFLAGS = -O2 -g -std=c99 -fno-strict-aliasing -Wall -W -D_GNU_SOURCE
 AM_YFLAGS = -d
 
@@ -12,7 +12,7 @@ nobase_noinst_HEADERS = ringbuffer.h configuration.h shctx.h miniobj.h \
 BUILT_SOURCES = cfg_parser.h
 hitch_SOURCES = configuration.c ringbuffer.c hitch.c vpf.c flopen.c vas.c \
 	cfg_parser.y cfg_lex.l vsb.c
-hitch_LDADD = $(AM_LDFLAGS) -lcrypto -lfl
+hitch_LDADD = $(AM_LDFLAGS) $(EV_LIBS) $(SSL_LIBS) -lfl
 if USE_SHCTX
 hitch_SOURCES += shctx.c
 hitch_LDADD += ebtree/libebtree.a


### PR DESCRIPTION
Should fix compilation under FreeBSD and remove the hardcoded path in EL6.

Fixes #74.