### PR TITLE
Add format checking to printf like functions

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -737,8 +737,7 @@ config_param_validate(char *k, char *v, hitch_config *cfg,
 			} else {
 				if (! S_ISDIR(st.st_mode)) {
 					config_error_set("Bad chroot directory "
-					    "'%s': Not a directory.", v,
-					    strerror(errno));
+					    "'%s': Not a directory", v);
 					r = 0;
 				} else {
 					config_assign_str(&cfg->CHROOT, v);

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -89,6 +89,10 @@ void cfg_cert_file_free(struct cfg_cert_file **cfptr);
 static char error_buf[CONFIG_BUF_SIZE];
 static char tmp_buf[150];
 
+/* declare static printf like functions: */
+static void config_error_set(char *fmt, ...)
+	__attribute__((format(printf, 1, 2)));
+
 static void
 config_error_set(char *fmt, ...)
 {

--- a/src/flopen.h
+++ b/src/flopen.h
@@ -31,7 +31,7 @@
 #ifndef FLOPEN_H_INCLUDED
 #define FLOPEN_H_INCLUDED
 
-int flopen(const char *, int, ...);
+int flopen(const char *, int, ...) __attribute__((format(printf, 1, 3)));
 int fltest(int fd, pid_t *pid);
 
 #endif

--- a/src/hitch.c
+++ b/src/hitch.c
@@ -333,6 +333,12 @@ typedef struct proxystate {
 	int			connect_port;	/* local port for connection */
 } proxystate;
 
+/* declare printf like functions: */
+static void WLOG(int level, const char *fmt, ...)
+	__attribute__((format(printf, 2, 3)));
+static void logproxy(int level, const proxystate* ps, const char *fmt, ...)
+	__attribute__((format(printf, 3, 4)));
+
 static void
 VWLOG(int level, const char *fmt, va_list ap)
 {

--- a/src/hitch.c
+++ b/src/hitch.c
@@ -493,17 +493,6 @@ fail(const char *s)
 	exit(1);
 }
 
-void
-die(char *fmt, ...)
-{
-	va_list args;
-	va_start(args, fmt);
-	vfprintf(stderr, fmt, args);
-	va_end(args);
-
-	exit(1);
-}
-
 #ifndef OPENSSL_NO_DH
 static int
 init_dh(SSL_CTX *ctx, const char *cert)

--- a/src/vsb.h
+++ b/src/vsb.h
@@ -63,7 +63,8 @@ struct vsb	*VSB_new(struct vsb *, char *, int, int);
 void		 VSB_clear(struct vsb *);
 int		 VSB_bcat(struct vsb *, const void *, ssize_t);
 int		 VSB_cat(struct vsb *, const char *);
-int		 VSB_printf(struct vsb *, const char *, ...);
+int		 VSB_printf(struct vsb *, const char *, ...)
+	__attribute__((format(printf, 2, 3)));
 #ifdef va_start
 int		 VSB_vprintf(struct vsb *, const char *, va_list);
 #endif


### PR DESCRIPTION
Add compiler macros for checking format strings vs actual arguments
to printf like functions. This revealed a tiny bug that is also being
fixed here.