### PR TITLE
Added pkg-config

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ It has been tested the most heavily on Linux/x86_64.
 
 Install prerequisites on Debian based systems:
 
-    $ sudo apt-get install libev-dev libssl-dev automake python-docutils flex bison
+    $ sudo apt-get install libev-dev libssl-dev automake python-docutils flex bison pkg-config
 
 To install `hitch`:
 


### PR DESCRIPTION
configure: error: The pkg-config script could not be found or is too old.  Make sure it
is in your PATH or set the PKG_CONFIG environment variable to the full
path to pkg-config.