### PR TITLE
Make rst2man optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,16 @@
 
 SUBDIRS = src
 
+if FOUND_RST2MAN
+
 hitch.8: hitch.man.rst
 	${RST2MAN} --halt=2 $(srcdir)/hitch.man.rst $@
 
+dist_man_MANS = hitch.8
+
+endif
+
 doc_DATA = hitch.conf.example CHANGES.rst README.md
 
-dist_man_MANS = hitch.8
 
 EXTRA_DIST = LICENSE README.md hitch.man.rst hitch.conf.example CHANGES.rst docs

--- a/configure.ac
+++ b/configure.ac
@@ -20,9 +20,9 @@ AC_ARG_WITH([rst2man],
   [RST2MAN="$withval"],
   AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], [no]))
 if test "x$RST2MAN" = "xno"; then
-  AC_MSG_ERROR(
-    [rst2man is needed to build Hitch, please install python-docutils. To proceed without building man pages, specify --with-rst2man=/bin/true.])
+  AC_MSG_WARN([rst2man/rst2man.py were not found, Hitch will lack man pages.  To fix this, please install python-docutils first and re-run configure.])
 fi
+AM_CONDITIONAL([FOUND_RST2MAN], [test "x$RST2MAN" = xyes])
 
 AM_MAINTAINER_MODE([disable])
 


### PR DESCRIPTION
Needing man pages isn't manly enough; and a warning about no man pages without rst2man{,.py}