### PR TITLE
Plug file descriptor leak

### DIFF
--- a/src/hitch.c
+++ b/src/hitch.c
@@ -3480,6 +3480,7 @@ reconfigure(int argc, char **argv)
 					break;
 				}
 			} while (i == -1 && errno == EINTR);
+			(void)close(c->pfd);
 		}
 	}
 


### PR DESCRIPTION
Killing worker processes would leave the pipe's write end open,
leaking one file descriptor per worker upon reload.

Fixes issue #193.