### PR TITLE
Put network includes after kernel includes

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -6,6 +6,9 @@
 
 #include "config.h"
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
@@ -15,10 +18,8 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <sys/types.h>
 #include <pwd.h>
 #include <grp.h>
-#include <sys/stat.h>
 #include <syslog.h>
 #include <libgen.h>
 

--- a/src/hitch.c
+++ b/src/hitch.c
@@ -37,21 +37,30 @@
 
 #include "config.h"
 
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>  /* TCP_NODELAY */
-#include <net/if.h>
-
-#include <libgen.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <sys/wait.h>  /* WAIT_PID */
+
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
+
+#ifdef __sun
+#include <sys/filio.h>
+#endif
+
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>  /* TCP_NODELAY */
 
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
 #include <grp.h>
+#include <libgen.h>
 #include <limits.h>
+#include <netdb.h>
 #include <pwd.h>
 #include <sched.h>
 #include <signal.h>
@@ -61,14 +70,6 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
-
-#ifdef __linux__
-#include <sys/prctl.h>
-#endif
-
-#ifdef __sun
-#include <sys/filio.h>
-#endif
 
 #include "configuration.h"
 #include "hitch.h"

--- a/src/logging.c
+++ b/src/logging.c
@@ -31,21 +31,22 @@
 
 #include "config.h"
 
-#include <netdb.h>
-#include <netinet/tcp.h>  /* TCP_NODELAY */
-#include <net/if.h>
-
-#include <libgen.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <sys/wait.h>  /* WAIT_PID */
+
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>  /* TCP_NODELAY */
 
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
 #include <grp.h>
+#include <libgen.h>
 #include <limits.h>
+#include <netdb.h>
 #include <pwd.h>
 #include <sched.h>
 #include <signal.h>

--- a/src/logging.h
+++ b/src/logging.h
@@ -34,13 +34,14 @@
 
 #include "config.h"
 
+#include <sys/types.h>
+#include <sys/ioctl.h>
+
 #include <arpa/inet.h>
 
 #include <ev.h>
 #include <stdio.h>
 #include <syslog.h>
-#include <sys/types.h>
-#include <sys/ioctl.h>
 
 // #include "asn_gentm.h"
 #include "configuration.h"

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -31,6 +31,7 @@
 
 #include <sys/select.h>
 #include <sys/socket.h>
+
 #include <unistd.h>
 
 #include "logging.h"

--- a/src/util/parse_proxy_v2.c
+++ b/src/util/parse_proxy_v2.c
@@ -35,14 +35,16 @@
  * correct thing to do.
  */
 
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <arpa/inet.h>
+
+#include <netdb.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <arpa/inet.h>
 #include <openssl/opensslv.h>
 
 unsigned char PROXY_V2_HEADER[12] = { 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,


### PR DESCRIPTION
Kernel includes usually come first, on OpenBSD the current order
would cause forward declarations of structures like sockaddr,
see http://man.openbsd.org/style for more information.

<netinet/in.h> requires <sys/types.h> on OpenBSD,
see http://man.openbsd.org/inet.

All tests continue to pass on Fedora 26 and Debian 9.1 both 64-bit.
Other platforms will most likely work as well, but more testing is
welcome.