### PR TITLE
Use correct ALPN protocol identifier in manual page

### DIFF
--- a/hitch.conf.man.rst
+++ b/hitch.conf.man.rst
@@ -322,7 +322,7 @@ The following file shows the syntax needed to get started with::
     group = "nogroup"
 
     # Enable to let clients negotiate HTTP/2 with ALPN. (default off)
-    # alpn-protos = "http/2, http/1.1"
+    # alpn-protos = "h2, http/1.1"
 
     # run Varnish as backend over PROXY; varnishd -a :80 -a localhost:6086,PROXY ..
     write-proxy-v2 = on             # Write PROXY header


### PR DESCRIPTION
It's h2 for HTTP/2 over TLS. All tests and documentation use the correct
identifier except for hitch(1) and its resulting hitch.conf.example so
fix them accordingly.

This avoids broken HTTP/2 support for users which will copy/uncomment
the alpn-protos line since client and server won't be able to negotiate
the protocol using the wrong identifier.