### PR TITLE
Fix strcmp(3) usage

### DIFF
--- a/src/cfg_parser.y
+++ b/src/cfg_parser.y
@@ -138,7 +138,7 @@ FB_REC
 FB_HOST: TOK_HOST '=' STRING
 {
 	if ($3) {
-		if (strcmp($3, "*"))
+		if (strcmp($3, "*") == 0)
 			cur_fa->ip = NULL;
 		else
 			cur_fa->ip = strdup($3);


### PR DESCRIPTION
Classic mistake introduced with db61acf and overlooked in 17e0410.

Fixes issue #194.