### PR TITLE
Fix sending out worker_update notification

### DIFF
--- a/src/hitch.c
+++ b/src/hitch.c
@@ -3479,7 +3479,7 @@ notify_workers(struct worker_update *wu)
 		     (wu->type == BACKEND_REFRESH)) {
 			errno = 0;
 			do {
-				i = write(c->pfd, (void*)wu, sizeof(wu));
+				i = write(c->pfd, (void*)wu, sizeof(struct worker_update));
 				if (i == -1 && errno != EINTR) {
 					if (wu->type == WORKER_GEN)
 						ERR("WARNING: {core} Unable to "

--- a/src/hitch.c
+++ b/src/hitch.c
@@ -3479,7 +3479,7 @@ notify_workers(struct worker_update *wu)
 		     (wu->type == BACKEND_REFRESH)) {
 			errno = 0;
 			do {
-				i = write(c->pfd, (void*)wu, sizeof(struct worker_update));
+				i = write(c->pfd, (void*)wu, sizeof(*wu));
 				if (i == -1 && errno != EINTR) {
 					if (wu->type == WORKER_GEN)
 						ERR("WARNING: {core} Unable to "


### PR DESCRIPTION
Send complete data for struct rather than sizeof (pointer)