### PR TITLE
Print parsing error messages correctly

### DIFF
--- a/src/cfg_parser.y
+++ b/src/cfg_parser.y
@@ -14,6 +14,7 @@ extern int yyparse(hitch_config *);
 extern FILE *yyin;
 int yyget_lineno(void);
 
+void config_error_set(char *, ...);
 int config_param_validate(char *k, char *v, hitch_config *cfg,
     char *file, int line);
 int front_arg_add(hitch_config *cfg, struct front_arg *fa);
@@ -537,7 +538,6 @@ yyerror(hitch_config *cfg, const char *s)
 	if (cur_fa != NULL)
 		FREE_OBJ(cur_fa);
 
-	fprintf(stderr, "Parsing error in line %d: %s\n", yyget_lineno(), s);
-	if (strlen(input_line) > 0)
-		fprintf(stderr, "'%s'", input_line);
+	config_error_set("Parsing error in line %d: %s: '%s'",
+	    yyget_lineno(), s, strlen(input_line) > 0 ? input_line : "");
 }

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -100,11 +100,11 @@ void cfg_cert_file_free(struct cfg_cert_file **cfptr);
 static char error_buf[CONFIG_BUF_SIZE];
 static char tmp_buf[150];
 
-/* declare static printf like functions: */
-static void config_error_set(char *fmt, ...)
+/* declare printf like functions: */
+void config_error_set(char *fmt, ...)
 	__attribute__((format(printf, 1, 2)));
 
-static void
+void
 config_error_set(char *fmt, ...)
 {
 	int len;


### PR DESCRIPTION
`Parsing error...` should be a specific message in the general reload
failure context but gets printed before that in `yyerror()`.

This diff sets error_buf instead so error messages look as intended.

Here's the broken and fixed output when reloading hitch after introducing
invalid syntax:

    Parsing error in line 4: syntax error
    'quiet = no'20171104T001003.129500 [20358] Config reload failed:
--

    20171104T001003.129500 [20358] Config reload failed: Parsing error in line 4: syntax error: 'quiet = no'