### PR TITLE
Add missing m4 for autoconf to fix FreeBSD port build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AM_CONDITIONAL([FOUND_RST2MAN], [test "x$RST2MAN" != xno])
 AM_MAINTAINER_MODE([disable])
 
 # Checks for libraries.
+m4_include([hitch.m4])
 PKG_CHECK_EXISTS([libev], [
 	PKG_CHECK_MODULES([EV], [libev])], [
 	HITCH_SEARCH_LIBS([EV], [ev], [ev_default_loop],


### PR DESCRIPTION
Add fix for FreeBSD port build.  Without this line, the port build fails with the following error:

`===>  Configuring for hitch-1.4.6                      
configure.ac:46: error: possibly undefined macro: AC_MSG_ERROR                      
      If this token and others are legitimate, please use m4_pattern_allow.                      
      See the Autoconf documentation.                      
autoreconf-2.69: /usr/local/bin/autoconf-2.69 failed with exit status: 1`