### PR TITLE
Include missing <limits.h>

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -22,6 +22,7 @@
 #include <grp.h>
 #include <syslog.h>
 #include <libgen.h>
+#include <limits.h>
 
 #include "configuration.h"
 #include "foreign/miniobj.h"


### PR DESCRIPTION
Required for INT_MAX et al.