### PR TITLE
tests: Improve hitch_hosts(), add configure checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,13 @@ AC_PROG_MAKE_SET
 AC_PROG_YACC
 AC_PROG_LEX
 
+AC_CHECK_PROGS(SOCKSTAT,
+	[lsof sockstat fstat],
+	[no])
+if test "x$SOCKSTAT" = "xno"; then
+	AC_MSG_WARN([No tool for socket inspection found, tests will fail.  To fix this, please install lsof, sockstat or fstat.])
+fi
+
 AC_ARG_WITH([rst2man],
   AS_HELP_STRING([--with-rst2man=PATH], [Location of rst2man (auto)]),
   [RST2MAN="$withval"],

--- a/src/tests/hitch_test.sh
+++ b/src/tests/hitch_test.sh
@@ -181,26 +181,22 @@ hitch_pid() {
 hitch_hosts() {
 	if command -v lsof >/dev/null
 	then
-		lsof -F -P -n -a -p "$(hitch_pid)" -i 4 -i TCP |
-		sed 's/*/localhost/' |
-		awk '/^n/ { print substr($1,2) }'
+		lsof -P -n -i 4 -a -p "$(hitch_pid)" |
+		awk '$8 == "TCP" { gsub("\\*", "localhost", $9); print $9 }'
 		return
 	fi
 
 	if command -v sockstat >/dev/null
 	then
-		sockstat -P tcp |
-		awk '$3 == '"$(hitch_pid)"' {print $6}' |
-		sort |
-		uniq |
-		sed 's:\*:localhost:'
+		sockstat -P "$(hitch_pid)" |
+		awk '$4 == "tcp4" { gsub("\\*", "localhost", $5); print $5 }'
 		return
 	fi
 
 	if command -v fstat >/dev/null
 	then
 		fstat -p "$(hitch_pid)" |
-		awk '$7 == "tcp" { gsub("\\*", "localhost", $9); print $9 }'
+		awk '$5 == "internet" && $7 == "tcp" { gsub("\\*", "localhost", $9); print $9 }'
 		return
 	fi
 

--- a/src/tests/hitch_test.sh
+++ b/src/tests/hitch_test.sh
@@ -197,7 +197,14 @@ hitch_hosts() {
 		return
 	fi
 
-	fail "neither lsof nor sockstat available"
+	if command -v fstat >/dev/null
+	then
+		fstat -p "$(hitch_pid)" |
+		awk '$7 == "tcp" { gsub("\\*", "localhost", $9); print $9 }'
+		return
+	fi
+
+	fail "none of lsof, sockstat or fstat available"
 }
 
 #-


### PR DESCRIPTION
This fixes `hitch_hosts()` on OpenBSD where **fstat(1)** or **netstat(1)** from
base are used in such cases.

Follow up to #209.