### PR TITLE
Prevent crash after reload with ocsp-dir change

### DIFF
--- a/src/hitch.c
+++ b/src/hitch.c
@@ -3680,7 +3680,8 @@ reconfigure(int argc, char **argv)
 	notify_workers(&wu);
 
 	if (CONFIG->OCSP_DIR != NULL) {
-		(void) kill(ocsp_proc_pid, SIGTERM);
+		if (ocsp_proc_pid != 0)
+			kill(ocsp_proc_pid, SIGTERM);
 		/*
 		 * Restarting the OCSP process is taken
 		 * care of in do_wait


### PR DESCRIPTION
Starting hitch with `ocsp-dir = ""` and reloading twice after setting
the option to any non-empty values results in sending SIGTERM to the
process ID 0 as no ocsp process will be forked during reconfiguration,
hence ocsp_proc_pid never changes.

This diff only prevents killing the main process, it does not fix the
broken logic.