### PR TITLE
Fix the handling of the session cache option passed to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_CHECK_MEMBERS([struct stat.st_mtim, struct stat.st_mtimespec])
 AC_ARG_ENABLE(sessioncache,
     AC_HELP_STRING([--enable-sessioncache],
 		   [Enable TLS session cache. (default is off)]),
-    [use_shctx="$withval"],
+    [use_shctx="$enableval"],
     [use_shctx=no])
 if test x"$use_shctx" != xno; then
   if test ! -e 'src/ebtree/ebtree.h'; then


### PR DESCRIPTION
Previously, $withval was used instead of $enableval in order to read
the option passed as argument.  Due to this bug, passing
--disable-sessioncache to configure would actually enable the feature.