### PR TITLE
Remove timestamps and pid from logged lines.

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -99,9 +99,7 @@ void
 VWLOG(int level, const char *fmt, va_list ap)
 {
 	struct timeval tv;
-	struct tm tm;
 	char buf[1024];
-	int n;
 	va_list ap1;
 
 	va_copy(ap1, ap);
@@ -113,6 +111,7 @@ VWLOG(int level, const char *fmt, va_list ap)
 		va_end(ap1);
 		return;
 	}
+
 	AZ(gettimeofday(&tv, NULL));
 	if (logfile != stdout && logfile != stderr
 	    && tv.tv_sec >= logf_check_t + LOG_REOPEN_INTERVAL) {
@@ -130,10 +129,7 @@ VWLOG(int level, const char *fmt, va_list ap)
 		logf_check_t = tv.tv_sec;
 	}
 
-	AN(localtime_r(&tv.tv_sec, &tm));
-	n = strftime(buf, sizeof(buf), "%Y%m%dT%H%M%S", &tm);
-	snprintf(buf + n, sizeof(buf) - n, ".%06d [%5d] %s",
-	    (int) tv.tv_usec, getpid(), fmt);
+	snprintf(buf, sizeof(buf), "%s", fmt);
 	vfprintf(logfile, buf, ap1);
 	va_end(ap1);
 }


### PR DESCRIPTION
This is a patch for #268 .

It should perhaps not remove the time stamp and pid if the output is sent to a log file, but wasn't straight forward to get right. This solves my immediate issue.