### PR TITLE
Add a subdirectory glob for pem-dir, allow use under frontend config sections

### DIFF
--- a/hitch.conf.man.rst
+++ b/hitch.conf.man.rst
@@ -262,6 +262,18 @@ Default is none (match any).
   pem-dir-glob = "*.pem"
 
 
+pem-dir-subdir-glob = <string>
+------------------------------
+
+Match filter for subdirectories of ``pem-dir`` to load files from.
+
+Default is none (do not match any subdirectories).
+
+::
+
+  pem-dir-subdir-glob = "*"
+
+
 prefer-server-ciphers = on|off
 ------------------------------
 

--- a/src/cfg_lex.l
+++ b/src/cfg_lex.l
@@ -87,6 +87,7 @@ char input_line[512];
 "ocsp-dir"		{ return (TOK_OCSP_DIR); }
 "pem-dir"               { return (TOK_PEM_DIR); }
 "pem-dir-glob"          { return (TOK_PEM_DIR_GLOB); }
+"pem-dir-subdir-glob"   { return (TOK_PEM_DIR_SUBDIR_GLOB); }
 "session-cache"	 	{ return (TOK_SESSION_CACHE); }
 "shared-cache-listen"	{ return (TOK_SHARED_CACHE_LISTEN); }
 "shared-cache-peer"  	{ return (TOK_SHARED_CACHE_PEER); }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -86,6 +86,9 @@ struct front_arg {
 	char			*port;
 	struct cfg_cert_file	*certs;
 	char			*pspec;
+	char                    *pem_dir;
+	char                    *pem_dir_glob;
+	char                    *pem_dir_subdir_glob;
 	int			match_global_certs;
 	int			sni_nomatch_abort;
 	int			prefer_server_ciphers;
@@ -148,6 +151,7 @@ struct __hitch_config {
     int TEST;
     char *PEM_DIR;
     char *PEM_DIR_GLOB;
+    char *PEM_DIR_SUBDIR_GLOB;
     int OCSP_VFY;
     char *OCSP_DIR;
     double OCSP_RESP_TMO;


### PR DESCRIPTION
Adds a new configuration option pem-dir-subdir-glob, which will (recursively) drag in matching subdirectories when scanning pem-dir. The semantics may not be great (matches directory name not full path), but it makes it a relatively simple change.

e.g.
pem-dir                    "/etc/hitch/pem.d"
pem-dir-subdir-glob "conf.d"
will also scan all subdirectories under /etc/hitch/pem.d named conf.d for pem files, "*" is generally more useful to include all subdirectories.

The change also allows pem-dir / pem-dir-glob / pem-dir-subdir-glob to be used inside frontend configuration sections.


