### PR TITLE
Rework the handling of optional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
 
 before_script:
   - ./bootstrap
-  - ./configure
   - make -j4
 
 script:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,13 +1,16 @@
+ACLOCAL_AMFLAGS = -I .
+
 SUBDIRS = src/util src
 
-if FOUND_RST2MAN
+dist_man_MANS = hitch.8 hitch.conf.5
+
+if ENABLE_DOCUMENTATION
 hitch.8: hitch.man.rst
 	${RST2MAN} --halt=2 $(srcdir)/hitch.man.rst $@
 
 hitch.conf.5: hitch.conf.man.rst
 	${RST2MAN} --halt=2 $(srcdir)/hitch.conf.man.rst $@
 
-dist_man_MANS = hitch.8 hitch.conf.5
 endif
 
 check-recursive: hitch.conf.example

--- a/bootstrap
+++ b/bootstrap
@@ -1,11 +1,21 @@
 #!/bin/sh
 
 set -e
-set -x
+set -u
+
+WORK_DIR=$(pwd)
+ROOT_DIR=$(dirname "$0")
+
+test -n "$ROOT_DIR"
+cd "$ROOT_DIR"
 
 mkdir -p build-aux
+autoreconf -i
 
-aclocal -I .
-autoconf
-autoheader
-automake --add-missing --foreign
+cd "$WORK_DIR"
+"$ROOT_DIR"/configure \
+	--enable-silent-rules \
+	--enable-documentation \
+	--with-lex \
+	--with-yacc \
+	"$@"

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([hitch], [1.5.0], [opensource@varnish-software.com])
 AC_CONFIG_SRCDIR([src/configuration.c])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
+AC_CONFIG_MACRO_DIR([.])
 
 AC_USE_SYSTEM_EXTENSIONS
 
@@ -17,7 +18,6 @@ AM_INIT_AUTOMAKE([
 	parallel-tests
 	subdir-objects
 ])
-AM_SILENT_RULES([yes])
 AM_PROG_AR
 
 # Checks for programs.
@@ -25,22 +25,34 @@ AM_PROG_CC_C_O
 AC_PROG_RANLIB
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-AC_PROG_YACC
-AC_PROG_LEX
+
+AC_ARG_WITH([lex],
+	AS_HELP_STRING([--with-lex], [Build with lex]),
+	[], [with_lex=no])
+AC_ARG_WITH([yacc],
+	AS_HELP_STRING([--with-yacc], [Build with yacc]),
+	[], [with_yacc=no])
+AC_ARG_ENABLE([documentation],
+	AS_HELP_STRING([--enable-documentation], [Build the documentation]),
+	[], [enable_documentation=no])
+
+test "$with_lex" = yes && AC_PROG_LEX
+test "$with_yacc" = yes && AC_PROG_YACC
+
+if test "$enable_documentation" = yes
+then
+	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], [no])
+	if test "$RST2MAN" = no
+	then
+		AC_MSG_ERROR([rst2man is needed to build the documentation])
+	fi
+fi
+AM_CONDITIONAL([ENABLE_DOCUMENTATION], [test "$enable_documentation" = yes])
 
 AC_CHECK_PROGS(SOCKSTAT, [lsof sockstat fstat], [no])
 if test "x$SOCKSTAT" = xno; then
 	AC_MSG_WARN([No tool found for socket inspection, tests will fail.])
 fi
-
-AC_ARG_WITH([rst2man],
-  AS_HELP_STRING([--with-rst2man=PATH], [Location of rst2man (auto)]),
-  [RST2MAN="$withval"],
-  AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], [no]))
-if test "x$RST2MAN" = "xno"; then
-  AC_MSG_WARN([rst2man/rst2man.py were not found, Hitch will lack man pages.  To fix this, please install python-docutils first and re-run configure.])
-fi
-AM_CONDITIONAL([FOUND_RST2MAN], [test "x$RST2MAN" != xno])
 
 AM_MAINTAINER_MODE([disable])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,3 @@
-
 sbin_PROGRAMS = hitch
 noinst_LIBRARIES = libcfg.a libforeign.a
 


### PR DESCRIPTION
There are multiple changes here, first we always ship the documentation
in the dist archive. This way, building a release from a dist archive no
longer requires rst2man. Unless downstream distributors modify the RST
files they don't need to rebuild the manuals.

The same is done for lex and yacc (or flex and bison) because we already
ship cfg_lex.c and cfg_parser.c in the dist archive. Unless downstream
distributors modify cfg_lex.l or cfg_parser.y they don't need to rebuild
those files.

Fixes #263

The last significant change is that ./bootstrap now invokes ./configure
and may take command line arguments such as --enable-sessioncache to
pass them on to the configure script:

    ./bootstrap --enable-sessioncache

Since the bootstrap script is meant for Hitch development, and not
redistribution it requires rst2man, lex/flex, yacc/bison to be present.

This means that we will need to adjust or development habits (this is
similar to what ./autogen.des does in Varnish) and build infrastrucure.