### PR TITLE
configure.ac: declare AC_CONFIG_MACRO_DIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([hitch], [1.5.0], [opensource@varnish-software.com])
 AC_CONFIG_SRCDIR([src/configuration.c])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
+AC_CONFIG_MACRO_DIR([.])
 
 AC_USE_SYSTEM_EXTENSIONS
 


### PR DESCRIPTION
This is related to issue #252.

When using autoconf 2.69:
configure.ac:51: error: possibly undefined macro: AC_MSG_ERROR

Proposed fix is to set AC_CONFIG_MACRO_DIR to the current directory.
 