### PR TITLE
SSL_CTX_set_ciphersuites needs to be used with TLSv1.3

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,10 @@ set of ciphers that suits your needs.
 
 Normally you do not have to change this.
 
+TLSv1.3 uses an indepentent list of ciphers, use ``ciphers_v3`` to change the default value:
+
+    "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+
 ## Using multiple certificates
 
 To add multiple certificates to the hitch config, simply specify multiple ``pem-file``

--- a/hitch.conf.man.rst
+++ b/hitch.conf.man.rst
@@ -85,6 +85,8 @@ Chroot directory
 ciphers = ...
 -------------
 
+For TLSv1.1 and TLSv1.2 connections. For TLSv1.3, see ciphers_v3.
+
 List of ciphers to use in the secure communication. Refer to the
 OpenSSL documentation for a complete list of supported ciphers.
 
@@ -94,6 +96,18 @@ the example file below) or to pay close attention to security advisories
 related OpenSSL's ciphers.
 
 This option is also available in frontend blocks.
+
+ciphers_v3 = ...
+----------------
+
+See ciphers.
+
+For TLSv1.3 connections, an independent list of ciphers is used. This list
+is made of new ciphers, which are not accepted by TLS1.1 and TLS1.2 and
+vica-versa, the old ciphers of TLS1.1 and TLS1.2 are not accepted by TLSv1.3
+
+To use TLSv1.1, TLSv1.2 along with TLSv1.3, both cipers and ciphers_v3 needs to be
+changed, if the default values are not desired.
 
 daemon = on|off
 ---------------

--- a/src/cfg_lex.l
+++ b/src/cfg_lex.l
@@ -47,6 +47,7 @@ char input_line[512];
 "TLSv1.2"			{ return (TOK_TLSv1_2); }
 "TLSv1.3"			{ return (TOK_TLSv1_3); }
 "ciphers"			{ return (TOK_CIPHERS); }
+"ciphers_v3"			{ return (TOK_CIPHERS_V3); }
 "ssl-engine"			{ return (TOK_SSL_ENGINE); }
 "prefer-server-ciphers"		{ return (TOK_PREFER_SERVER_CIPHERS); }
 "workers"			{ return (TOK_WORKERS); }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -87,6 +87,7 @@ struct front_arg {
 	int			sni_nomatch_abort;
 	int			prefer_server_ciphers;
 	char			*ciphers;
+	char			*ciphers_v3;
 	int			selected_protos;
 	int			mark;
 	UT_hash_handle		hh;
@@ -117,6 +118,7 @@ struct __hitch_config {
 	struct cfg_cert_file	*CERT_FILES;
 	struct cfg_cert_file	*CERT_DEFAULT;
 	char			*CIPHER_SUITE;
+	char			*CIPHER_SUITE_V3;
 	char			*ENGINE;
 	int			BACKLOG;
 #ifdef USE_SHARED_CACHE

--- a/src/tests/test34-tls-ciphers-tls1_3.sh
+++ b/src/tests/test34-tls-ciphers-tls1_3.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Test TLS 1.3 chipers.
+
+. hitch_test.sh
+
+if ! openssl s_client -help 2>&1 | grep -q -e "-tls1_3";
+then
+    skip "Missing TLSv1.3 support"
+fi
+
+# only TLSv1.3
+cat >hitch.cfg <<EOF
+backend = "[hitch-tls.org]:80"
+frontend = "[*]:$LISTENPORT"
+pem-file = "${CERTSDIR}/default.example.com"
+ciphers_v3 = "TLS_CHACHA20_POLY1305_SHA256"
+tls-protos = TLSv1.3
+EOF
+
+start_hitch --config=hitch.cfg
+
+# Get the cipher from hitch conf, not the default
+s_client >s_client.dump
+! grep -q "Cipher is TLS_AES_256_GCM_SHA384" s_client.dump
+run_cmd grep -q "Cipher is TLS_CHACHA20_POLY1305_SHA256" s_client.dump


### PR DESCRIPTION
Fixes #303

DRAFT, needs documentation.

Executive summary: TLSv1,2 uses `SSL_CTX_set_cipher_list`, TLSv3 uses independently another cipher list, set by `SSL_CTX_set_ciphersuites`.

The 2 cipher list is independent, hence the introduced new parameter: `ciphers_v3`