### PR TITLE
Quote some commandline examples for the shell

### DIFF
--- a/docs/certificates.md
+++ b/docs/certificates.md
@@ -33,7 +33,7 @@ To complete this chain you merge the files into a single PEM file that you give 
 
 And then start Hitch:
 
-    $ hitch --backend=[127.0.0.1]:80 example.pem
+    $ hitch --backend='[127.0.0.1]:80' example.pem
 
 and you're done!
 

--- a/docs/vhosts.md
+++ b/docs/vhosts.md
@@ -9,7 +9,7 @@ handshake decide which certificate to present to the client.
 *SNI example*:
 
 	$ ./hitch --backend=example.com:80 \
-		--frontend=[*]:443 \
+		--frontend='[*]:443' \
 		site1.example.com.pem site2.example.com.pem site3.example.com.pem
 
 Hitch will automatically try to find the best matching certificate to give to the client. The last


### PR DESCRIPTION
Minor issue, but otherwise it doesn't work for me:

	$ hitch --backend=[127.0.0.1]:80 example.pem
	zsh: no matches found: --backend=[127.0.0.1]:80

	$ hitch --backend='[127.0.0.1]:80' example.pem
	{ocsp} Warning: Unable to stat directory '/var/lib/hitch/': No such file or directory'. OCSP stapling will be disabled.
	20190731T174522.283111 [14333] {core} hitch 1.5.0 starting
	20190731T174522.285965 [14333] {core} Loading certificate pem files (1)
	20190731T174522.286491 [14333] {core} hitch 1.5.0 initialization complete
	20190731T174522.286569 [14334] {core} Process 0 online

Probably depends on your shell/settings whether or not it's needed, but
doesn't hurt to add them.