### PR TITLE
Allow running workers as root, if both UID and GID are specified as root

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,8 @@ If you're handling a large number of connections, you'll probably want to raise
 If you are listening to ports under 1024 (443 comes to mind), you need
 to start Hitch as root. In those cases you *must* use --user/-u to set
 a non-privileged user `hitch` can setuid() to.
+If you are aware of the security implications and insist on running the worker
+threads as root too, both the user and the group must be set to root.
 
 
 ## Preparing PEM files


### PR DESCRIPTION
Fixes #320

Originally, running workers as root was disabled, as unintentional
root privilages are a security threat.

But if the user really wants to run hitch as root, it is possible now,
it is just difficult enough not to happen by default conriguration
values.