### PR TITLE
Fix build with OpenSSL-without-NPN/ALPN

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1651,7 +1651,7 @@ CFG_ON('s', CFG_SYSLOG);
 #else
 		/* No support for ALPN / NPN support in OpenSSL */
 		if (multi_proto ||
-		    0 != strncmp(cfg->ALPN_PROTOS_LV, "\x8http/1.1", 9)) {
+		    0 != strncmp((char *)cfg->ALPN_PROTOS_LV, "\x8http/1.1", 9)) {
 			config_error_set("This is compiled against OpenSSL version"
 			    " %lx, which does not have NPN or ALPN support,"
 			    " yet alpn-protos has been set to %s.",

--- a/src/hitch.c
+++ b/src/hitch.c
@@ -1984,6 +1984,7 @@ start_handshake(proxystate *ps, int err)
 	ev_timer_start(loop, &ps->ev_t_handshake);
 }
 
+#if defined(OPENSSL_WITH_NPN) || defined(OPENSSL_WITH_ALPN)
 static void
 get_alpn(proxystate *ps, const unsigned char **selected, unsigned *len) {
 	*selected = NULL;
@@ -1996,6 +1997,7 @@ get_alpn(proxystate *ps, const unsigned char **selected, unsigned *len) {
 		SSL_get0_next_proto_negotiated(ps->ssl, selected, len);
 #endif
 }
+#endif /* OPENSSL_WITH_NPN || OPENSSL_WITH_ALPN */
 
 static int
 proxy_tlv_append(char *dst, ssize_t dstlen, unsigned type,


### PR DESCRIPTION
```hs
Fixes:

    gcc -DHAVE_CONFIG_H -I. -I../../src -I..    -g -O2 -Wall -W -Werror   -fno-strict-aliasing   -O0 -ggdb3 -MT hitch-configuration.o -MD -MP -MF .deps/hitch-configuration.Tpo -c -o hitch-configuration.o `test -f 'configuration.c' || echo '../../src/'`configuration.c
    ../../src/configuration.c: In function ‘config_parse_cli’:
    ../../src/configuration.c:1654:23: error: pointer targets in passing argument 1 of ‘strncmp’ differ in signedness [-Werror=pointer-sign]
           0 != strncmp(cfg->ALPN_PROTOS_LV, "\x8http/1.1", 9)) {
                        ~~~^~~~~~~~~~~~~~~~

    gcc -DHAVE_CONFIG_H -I. -I../../src -I..    -g -O2 -Wall -W -Werror   -fno-strict-aliasing   -O0 -ggdb3 -MT hitch-hitch.o -MD -MP -MF .deps/hitch-hitch.Tpo -c -o hitch-hitch.o `test -f 'hitch.c' || echo '../../src/'`hitch.c
    ../../src/hitch.c: In function ‘get_alpn’:
    ../../src/hitch.c:1988:22: error: unused parameter ‘ps’ [-Werror=unused-parameter]
     get_alpn(proxystate *ps, const unsigned char **selected, unsigned *len) {
              ~~~~~~~~~~~~^~
    At top level:
    ../../src/hitch.c:1988:1: error: ‘get_alpn’ defined but not used [-Werror=unused-function]
     get_alpn(proxystate *ps, const unsigned char **selected, unsigned *len) {
     ^~~~~~~~
```
