### PR TITLE
Ntgr

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,16 +2,14 @@ ACLOCAL_AMFLAGS = -I .
 
 SUBDIRS = src/util src
 
+if ENABLE_DOCUMENTATION
 dist_man_MANS = hitch.8 hitch.conf.5
 
-if ENABLE_DOCUMENTATION
 hitch.8: hitch.man.rst
 	${RST2MAN} --halt=2 $(srcdir)/hitch.man.rst $@
 
 hitch.conf.5: hitch.conf.man.rst
 	${RST2MAN} --halt=2 $(srcdir)/hitch.conf.man.rst $@
-
-endif
 
 check-recursive: hitch.conf.example
 
@@ -27,3 +25,4 @@ dist_doc_DATA = hitch.conf.example CHANGES.rst README.md
 
 EXTRA_DIST = LICENSE hitch.man.rst hitch.conf.man.rst docs
 CLEANFILES = hitch.conf.example
+endif

--- a/hitch.m4
+++ b/hitch.m4
@@ -24,7 +24,7 @@ AC_DEFUN([_HITCH_CHECK_FLAG], [
 	AC_MSG_CHECKING([whether the compiler accepts $2])
 	hitch_save_CFLAGS=$CFLAGS
 	CFLAGS="[$]$1 $2 $CFLAGS"
-	AC_RUN_IFELSE(
+	AC_LINK_IFELSE(
 		[AC_LANG_SOURCE([int main(void) { return (0); }])],
 		[AC_MSG_RESULT([yes]); $1="[$]$1 $2"],
 		[AC_MSG_RESULT([no])])

--- a/src/hitch.c
+++ b/src/hitch.c
@@ -39,6 +39,7 @@
 
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
+#include <openssl/engine.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
A couple of tweaks required to allow cross-compiling for OpenWrt with the following settings:

CONFIGURE_ARGS+= \
    --enable-silent-rules \
    --with-lex \
    --with-yacc \

CONFIGURE_VARS += \
    ac_cv_so_reuseport_works=yes \
    ac_cv_so_tfo=yes
