### PR TITLE
Add auto value to create 1 worker per CPU core

### DIFF
--- a/hitch.conf.man.rst
+++ b/hitch.conf.man.rst
@@ -426,10 +426,11 @@ user = <string>
 User to run as. If Hitch is started as root, it will insist on
 changing to a user with lower rights after binding to sockets.
 
-workers = <number>
+workers = <number>|auto
 ------------------
 
 Number of worker processes. One per CPU core is recommended.
+Using auto value creates 1 worker per CPU core
 
 write-ip = on|off
 -----------------

--- a/hitch.man.rst
+++ b/hitch.man.rst
@@ -84,10 +84,11 @@ also take a UNIX domain socket path E.g. --backend="/path/to/sock"
 Frontend listen endpoint (default is "[*]:8443") (Note: brackets are
 mandatory in endpoint specifiers.)
 
-``-n  --workers=NUM``
+``-n  --workers=NUM|auto``
 ---------------------
 
 Number of worker processes (Default: 1)
+Using auto value creates 1 worker per CPU core
 
 ``-B  --backlog=NUM``
 ---------------------

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -8,6 +8,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysinfo.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -543,6 +544,21 @@ config_param_val_long(char *str, long *dst, int non_negative)
 	return (1);
 }
 
+static int
+config_param_val_workers(char *str, long *dst, int non_negative)
+{
+	assert(str != NULL);
+
+	if (strcasecmp(str, "auto") == 0) {
+		/* Get number of active CPU */
+		*dst = get_nprocs_conf();
+	}
+	else {
+		return config_param_val_long(str, dst, non_negative);
+	}
+	return (1);
+}
+
 static double
 mtim2double(const struct stat *sb)
 {
@@ -893,7 +909,7 @@ config_param_validate(const char *k, char *v, hitch_config *cfg,
 		r = config_param_host_port(v, &cfg->BACK_IP, &cfg->BACK_PORT,
 		    &cfg->BACK_PATH);
 	} else if (strcmp(k, CFG_WORKERS) == 0) {
-		r = config_param_val_long(v, &cfg->NCORES, 1);
+		r = config_param_val_workers(v, &cfg->NCORES, 1);
 	} else if (strcmp(k, CFG_BACKLOG) == 0) {
 		r = config_param_val_int(v, &cfg->BACKLOG, 0);
 	} else if (strcmp(k, CFG_KEEPALIVE) == 0) {


### PR DESCRIPTION
When trying to deploy the same configuration to multiple different machines, the need for a specific configuration depending on the hardware was tricky.
Using "auto" value automatically creates 1 worker per CPU core, making the configuration easier.