### PR TITLE
Fix a few typos

### DIFF
--- a/hitch.conf.man.rst
+++ b/hitch.conf.man.rst
@@ -270,11 +270,11 @@ certificate listed will be used if none of the others match.
 
 In the event that we have multiple certificates that provide the same
 SNI string, an error will be logged. The last loaded certificate will
-in that case take precendence.
+in that case take precedence.
 
 For partial overlap in names, e.g. if one certificate provides
 "www.example.com" and another one "\*.example.com", the most specific
-match will always take precendence at SNI lookup.
+match will always take precedence at SNI lookup.
 
 This option is also available in a frontend declaration, to make a
 certificate only available for a specific listen endpoint.

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1205,7 +1205,7 @@ config_scan_pem_dir(char *pemdir, hitch_config *cfg)
 		AN(fpath);
 
 		if (snprintf(fpath, plen, "%s%s", pemdir, d[i]->d_name) < 0) {
-			config_error_set("An error occured while "
+			config_error_set("An error occurred while "
 			    "combining path");
 			free(fpath);
 			retval = 1;


### PR DESCRIPTION
Fix a few typos caught by "lintian" after building debian packages.