### PR TITLE
Fix build under FreeBSD: we have no sys/sysinfo.h

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -8,7 +8,9 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifndef __FreeBSD__
 #include <sys/sysinfo.h>
+#endif
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Disable include for sys/sysinfo.h when building under FreeBSD to fix build.