### PR TITLE
Update URL for Mozilla ssl-config generator

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,8 +29,7 @@ The recommended default is:
 If you need to support legacy clients, consider the "HIGH" cipher group.
 
 Hitch cipher list string format is identical to that of other servers, so you can use
-tools like https://mozilla.github.io/server-side-tls/ssl-config-generator/ to generate a
-set of ciphers that suits your needs.
+tools like https://ssl-config.mozilla.org/ to generate a set of ciphers that suits your needs.
 
 Normally you do not have to change this.
 


### PR DESCRIPTION
Old URL was redirected, new URL is used since quite a while now.